### PR TITLE
Run CI at each push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@ on:
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - main
+    tags: '*'
 concurrency:
   # Skip intermediate builds: all builds except for builds on the `main` branch
   # Cancel intermediate builds: only pull request builds


### PR DESCRIPTION
I think this is required for the build status badge on the README.